### PR TITLE
PWM Fix

### DIFF
--- a/software/tinyclr/tutorials/pwm.md
+++ b/software/tinyclr/tutorials/pwm.md
@@ -95,7 +95,9 @@ class Program
         {
             for (int i = 0; i < note.Length; i++)
             {
+                tones.Stop();
                 Controller1.SetDesiredFrequency( note[i]);
+                tones.Start();
                 Thread.Sleep(duration[i]);
             }
             Thread.Sleep(100);


### PR DESCRIPTION
There is a bug in PWM dealing with a possible timer overflow where you need to call Stop(), change frequency, and then call Start() again to allow the PWM to work. This was discovered while using the Musical Tones section. I am not sure if the problem will present itself with the other examples.