### PR TITLE
In UCM tables changed references to "BOOT X" and added LDR0, LDR1, an…

### DIFF
--- a/hardware/ucm/g400d.md
+++ b/hardware/ucm/g400d.md
@@ -183,11 +183,11 @@ The G400D datasheet can be found [here](http://files.ghielectronics.com/download
 | 104           | ADC C                         | PB12, ADC1                                    |
 | 105           | PWM A                         | PC18, PWM0                                    |
 | 106           | 3.3V                          | 3.3V                                          |
-| 107           | Bootstrap A                   | SPI1 MISO                                     |
+| 107           | BOOT A                        | SPI1 MISO                                     |
 | 108           | Module Specific 2             | SPI1 MOSI                                     |
 | 109           | Module Specific 3             | SPI1 SCK                                      |
 | 110           | ADC D                         | PB17, ADC6                                    |
-| 111           | Bootstrap C                   | PA4, LDR1                                     |
+| 111           | BOOT C                        | PA4, LDR1                                     |
 | 112           | PWM B                         | PC19, PWM1                                    |
 | 113           | GND                           | GND                                           |
 | 114           | ADC E                         | PB16, ADC5                                    |
@@ -210,8 +210,8 @@ The G400D datasheet can be found [here](http://files.ghielectronics.com/download
 | 131           | GND                           | GND                                           |
 | 132           | GPIO K                        | PC26                                          |
 | 133           | PWM D                         | PC20, PWM2                                    |
-| 134           | Bootstrap B                   | PA24                                          |
-| 135           | Bootstrap D                   | PA25                                          |
+| 134           | BOOT B                        | PA24, LDR0                                    |
+| 135           | BOOT D                        | PA25, MODE                                    |
 | 136           | GPIO L                        | PA26                                          |
 | 137           | Module Specific 10            | PA27                                          |
 | 138           | UART HS B RTS                 |                                               |

--- a/hardware/ucm/uc2550.md
+++ b/hardware/ucm/uc2550.md
@@ -188,11 +188,11 @@ We also offer customized, non-stock versions of our SoMs. Many options are avail
 | 104           | ADC C                         | PA2, ADC2, TIM5 CH3                     |
 | 105           | PWM A                         | PE9, TIM1 CH1                           |
 | 106           | 3.3V                          | 3.3V                                    |
-| 107           | System A                      | BOOT0                                   |
+| 107           | BOOT A                        | BOOT0                                   |
 | 108           | Module Specific 2             | (Wi-Fi PIN2)                            |
 | 109           | Module Specific 3             | (Wi-Fi PIN4)                            |
 | 110           | ADC D                         | PA3, ADC3, TIM5 CH4                     |
-| 111           | System C                      | PE3                                     |
+| 111           | BOOT C                        | PE3, LDR1                               |
 | 112           | PWM B                         | PE11, TIM1 CH2                          |
 | 113           | GND                           | GND                                     |
 | 114           | ADC E                         | PA4, ADC4, DAC1                         |
@@ -215,8 +215,8 @@ We also offer customized, non-stock versions of our SoMs. Many options are avail
 | 131           | GND                           | GND                                     |
 | 132           | GPIO K                        |                                         |
 | 133           | PWM D                         | PC7, TIM3 CH2, USART6 RX                |
-| 134           | System B                      | PB2                                     |
-| 135           | System D                      | PE4                                     |
+| 134           | BOOT B                        | PB2, LDR0                               |
+| 135           | BOOT D                        | PE4, MODE                               |
 | 136           | GPIO L                        |                                         |
 | 137           | Module Specific 10            |                                         |
 | 138           | UART HS B RTS                 | PD12, USART3 RTS                        |

--- a/hardware/ucm/uc5550.md
+++ b/hardware/ucm/uc5550.md
@@ -190,11 +190,11 @@ We also offer customized, non-stock versions of our SoMs. Many options are avail
 | 104           | ADC C                      | PA5, ADC5, DAC2                         |
 | 105           | PWM A                      | PA15, TIM2 CH1                          |
 | 106           | 3.3V                       | 3.3V                                    |
-| 107           | System A                   | BOOT                                    |
+| 107           | BOOT A                     | BOOT                                    |
 | 108           | Module Specific 2          | (Wi-Fi PIN2)                            |
 | 109           | Module Specific 3          | (Wi-Fi PIN4)                            |
 | 110           | ADC D                      | PB0, ADC8, TIM3 CH3                     |
-| 111           | System C                   | PI1                                     |
+| 111           | BOOT C                     | PI1, LDR1                               |
 | 112           | PWM B                      | PB7, TIM4 CH2                           |
 | 113           | GND                        | GND                                     |
 | 114           | ADC E                      | PB1, ADC9, TIM3 CH4                     |
@@ -217,8 +217,8 @@ We also offer customized, non-stock versions of our SoMs. Many options are avail
 | 131           | GND                        | GND                                     |
 | 132           | GPIO K                     | PC4, ETH RMII RXD0                      |
 | 133           | PWM D                      | PI5, TIM8 CH1                           |
-| 134           | System B                   | PB2                                     |
-| 135           | System D                   | PI3                                     |
+| 134           | BOOT B                     | PB2, LDR0                               |
+| 135           | BOOT D                     | PI3, MODE                               |
 | 136           | GPIO L                     | PC5, ETH RMII RXD1                      |
 | 137           | Module Specific 10         | (ETH PHY OSCILLATOR PIN1) OE OFF#       |
 | 138           | UART HS B RTS              |                                         |


### PR DESCRIPTION
…d MODE. Fixes #147.