### PR TITLE
Added note to reference GHIElectronics.TinyCLR.Pins

### DIFF
--- a/software/tinyclr/tutorials/gpio.md
+++ b/software/tinyclr/tutorials/gpio.md
@@ -3,7 +3,7 @@
 Microcontrollers include pins that can be controlled through software. They can be inputs or outputs, hence the name "general purpose input/output," or GPIO for short.
 
 > [!Tip]
-> GPIO is handled by using GHIElectronics.TinyCLR.Devices.Gpio and GHIElectronics.TinyCLR.Pins through the NuGet Devices package.
+> GPIO is found in the GHIElectronics.TinyCLR.Devices.Gpio NuGet package and pin definitions are found in the  GHIElectronics.TinyCLR.Pins package.
 
 ## Digital Outputs
 A digital output pin can be set to either high or low. There are different ways of describing these two states. High can also be called "true" or "one;" low can be called "false" or "zero".

--- a/software/tinyclr/tutorials/gpio.md
+++ b/software/tinyclr/tutorials/gpio.md
@@ -3,7 +3,7 @@
 Microcontrollers include pins that can be controlled through software. They can be inputs or outputs, hence the name "general purpose input/output," or GPIO for short.
 
 > [!Tip]
-> GPIO is handled by using GHIElectronics.TinyCLR.Devices.Gpio through the NuGet Devices package.
+> GPIO is handled by using GHIElectronics.TinyCLR.Devices.Gpio and GHIElectronics.TinyCLR.Pins through the NuGet Devices package.
 
 ## Digital Outputs
 A digital output pin can be set to either high or low. There are different ways of describing these two states. High can also be called "true" or "one;" low can be called "false" or "zero".


### PR DESCRIPTION
Noted at the beginning people will need to also reference the GHIElectronics.TinyCLR.Pins NuGet package. Most people coming to this page will assume it's part of the GHIElectronics.TinyCLR.Devices meta-package, but it's not.